### PR TITLE
feat(content): replace BS4 get_text with Trafilatura + BS4 fallback

### DIFF
--- a/benchmarks/.gitignore
+++ b/benchmarks/.gitignore
@@ -1,0 +1,1 @@
+fixtures/*.html

--- a/benchmarks/extractor_bench.py
+++ b/benchmarks/extractor_bench.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Benchmark content-extraction quality and latency.
+
+Strategy:
+  1. Fetch a fixed corpus of representative URLs once (Wikipedia, news,
+     docs, blogs). Save HTML to ``benchmarks/fixtures/`` so re-runs are
+     reproducible without network.
+  2. For each extractor, measure on each fixture:
+       - wall_time_ms (median of 5 runs)
+       - chars_out
+       - words_out
+       - boilerplate_ratio (presence of cookie/nav/footer words in output)
+  3. Emit a side-by-side Markdown table to stdout and a JSON record so the
+     PR description can include reproducible numbers.
+
+Run:
+    .venv/bin/python benchmarks/extractor_bench.py            # use cached fixtures
+    .venv/bin/python benchmarks/extractor_bench.py --refetch  # re-download
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import sys
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Callable, Dict, List
+
+# Make src importable without installing
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import requests  # noqa: E402
+
+FIXTURES = ROOT / "benchmarks" / "fixtures"
+FIXTURES.mkdir(parents=True, exist_ok=True)
+
+# Curated corpus: news, encyclopedia, docs, blog, ecommerce-style.
+# Keep small — we want representative, not comprehensive.
+CORPUS: Dict[str, str] = {
+    "wikipedia_python": "https://en.wikipedia.org/wiki/Python_(programming_language)",
+    "wikipedia_quantum": "https://en.wikipedia.org/wiki/Quantum_computing",
+    "python_docs_tutorial": "https://docs.python.org/3/tutorial/index.html",
+    "mdn_javascript": "https://developer.mozilla.org/en-US/docs/Web/JavaScript",
+    "reddit_thread": "https://www.reddit.com/r/Python/comments/1bz5emi/python_312_release_notes/",
+    "github_readme": "https://github.com/vishalkg/web-search",
+    "blog_post": "https://lilianweng.github.io/posts/2023-06-23-agent/",
+    "news_article": "https://www.bbc.com/news/technology",
+}
+
+# Words/phrases that almost always come from boilerplate (nav, cookie banners,
+# footer, share widgets). Used as a heuristic boilerplate-leakage measure —
+# the cleaner the extractor, the lower this ratio.
+BOILERPLATE_MARKERS = [
+    "cookie",
+    "subscribe",
+    "newsletter",
+    "sign in",
+    "log in",
+    "privacy policy",
+    "terms of service",
+    "all rights reserved",
+    "skip to content",
+    "follow us",
+    "share this",
+    "table of contents",
+    "navigation menu",
+    "search this site",
+]
+
+
+@dataclass
+class ExtractorResult:
+    extractor: str
+    fixture: str
+    wall_time_ms: float
+    chars_out: int
+    words_out: int
+    boilerplate_hits: int
+
+
+def fetch_fixtures(urls: Dict[str, str], force: bool) -> Dict[str, str]:
+    """Download or load HTML fixtures. Returns name -> raw_html."""
+    out: Dict[str, str] = {}
+    headers = {
+        "User-Agent": (
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+        )
+    }
+    for name, url in urls.items():
+        path = FIXTURES / f"{name}.html"
+        if path.exists() and not force:
+            out[name] = path.read_text(encoding="utf-8", errors="replace")
+            continue
+        print(f"  fetching {name}: {url}", file=sys.stderr)
+        try:
+            resp = requests.get(url, headers=headers, timeout=20)
+            resp.raise_for_status()
+            html = resp.text
+            path.write_text(html, encoding="utf-8")
+            out[name] = html
+        except Exception as exc:  # noqa: BLE001
+            print(f"    SKIP {name}: {exc}", file=sys.stderr)
+    return out
+
+
+def measure(extractor_fn: Callable[[str], str], html: str, runs: int = 5) -> float:
+    """Median wall time across N runs (ms)."""
+    timings: List[float] = []
+    for _ in range(runs):
+        t0 = time.perf_counter()
+        extractor_fn(html)
+        timings.append((time.perf_counter() - t0) * 1000)
+    return statistics.median(timings)
+
+
+def boilerplate_score(text: str) -> int:
+    lower = text.lower()
+    return sum(lower.count(m) for m in BOILERPLATE_MARKERS)
+
+
+def run_extractor(
+    name: str, fn: Callable[[str], str], fixtures: Dict[str, str]
+) -> List[ExtractorResult]:
+    results: List[ExtractorResult] = []
+    for fixture_name, html in fixtures.items():
+        try:
+            wall_ms = measure(fn, html)
+            output = fn(html) or ""
+        except Exception as exc:  # noqa: BLE001
+            print(f"  {name} crashed on {fixture_name}: {exc}", file=sys.stderr)
+            continue
+        results.append(
+            ExtractorResult(
+                extractor=name,
+                fixture=fixture_name,
+                wall_time_ms=round(wall_ms, 2),
+                chars_out=len(output),
+                words_out=len(output.split()),
+                boilerplate_hits=boilerplate_score(output),
+            )
+        )
+    return results
+
+
+def make_extractors() -> Dict[str, Callable[[str], str]]:
+    """Return name -> extractor callable.
+
+    Three candidates:
+      - ``bs4_old``: the pre-PR pure-BeautifulSoup extractor (kept inline).
+      - ``trafilatura_only``: Trafilatura without any fallback.
+      - ``current``: whatever ``websearch.utils.content.extract_text_content``
+        is on this branch — the actual production code path.
+    """
+    extractors: Dict[str, Callable[[str], str]] = {}
+
+    # Pre-PR baseline: pure BeautifulSoup get_text — kept inline so the
+    # benchmark stays comparable even after the production code is replaced.
+    def _bs4_old(html: str) -> str:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        for s in soup(["script", "style"]):
+            s.decompose()
+        text = soup.get_text()
+        lines = (line.strip() for line in text.splitlines())
+        chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
+        return " ".join(chunk for chunk in chunks if chunk)
+
+    extractors["bs4_old"] = _bs4_old
+
+    try:
+        import trafilatura  # noqa: WPS433
+
+        def _trafilatura(html: str) -> str:
+            return trafilatura.extract(html, include_comments=False) or ""
+
+        extractors["trafilatura_only"] = _trafilatura
+    except ImportError:
+        print("  (trafilatura not installed; skipping)", file=sys.stderr)
+
+    from websearch.utils.content import extract_text_content as _current
+
+    extractors["current"] = _current
+
+    return extractors
+
+
+def render_table(results: List[ExtractorResult]) -> str:
+    """Markdown table with one row per (extractor, fixture)."""
+    by_fixture: Dict[str, Dict[str, ExtractorResult]] = {}
+    for r in results:
+        by_fixture.setdefault(r.fixture, {})[r.extractor] = r
+
+    lines = []
+    lines.append("| fixture | extractor | wall_ms | chars | words | boilerplate_hits |")
+    lines.append("|---|---|---:|---:|---:|---:|")
+    for fixture, by_ext in sorted(by_fixture.items()):
+        for ext_name, r in sorted(by_ext.items()):
+            lines.append(
+                f"| {fixture} | {ext_name} | {r.wall_time_ms} | {r.chars_out} | "
+                f"{r.words_out} | {r.boilerplate_hits} |"
+            )
+    return "\n".join(lines)
+
+
+def render_summary(results: List[ExtractorResult]) -> str:
+    """Aggregate per-extractor totals."""
+    by_ext: Dict[str, List[ExtractorResult]] = {}
+    for r in results:
+        by_ext.setdefault(r.extractor, []).append(r)
+
+    lines = ["", "**Aggregate (sum across all fixtures):**", ""]
+    lines.append("| extractor | total_chars | total_words | total_ms | total_boilerplate |")
+    lines.append("|---|---:|---:|---:|---:|")
+    for ext, rs in sorted(by_ext.items()):
+        lines.append(
+            f"| {ext} | {sum(r.chars_out for r in rs)} | {sum(r.words_out for r in rs)} | "
+            f"{round(sum(r.wall_time_ms for r in rs), 2)} | "
+            f"{sum(r.boilerplate_hits for r in rs)} |"
+        )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--refetch", action="store_true", help="Re-download HTML fixtures")
+    p.add_argument("--json", help="Write raw results as JSON to this path")
+    args = p.parse_args()
+
+    print("Loading fixtures...", file=sys.stderr)
+    fixtures = fetch_fixtures(CORPUS, force=args.refetch)
+    if not fixtures:
+        print("No fixtures available — run with --refetch first.", file=sys.stderr)
+        return 1
+    print(f"  {len(fixtures)} fixtures loaded", file=sys.stderr)
+
+    extractors = make_extractors()
+    print(f"  extractors: {sorted(extractors)}", file=sys.stderr)
+
+    all_results: List[ExtractorResult] = []
+    for name, fn in extractors.items():
+        print(f"Running {name}...", file=sys.stderr)
+        all_results.extend(run_extractor(name, fn, fixtures))
+
+    print(render_table(all_results))
+    print(render_summary(all_results))
+
+    if args.json:
+        Path(args.json).write_text(
+            json.dumps([asdict(r) for r in all_results], indent=2)
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "websearch"
-version = "2.2.0"
+version = "2.3.0"
 description = "Advanced web search and content extraction MCP server with multi-engine support"
 authors = ["Vishal Gupta <vishal@example.com>"]
 license = "MIT"
@@ -21,6 +21,7 @@ lxml = "^6.1.0"
 python-dotenv = "^1.2.2"
 google-api-python-client = "^2.196.0"
 platformdirs = "^4.9.6"
+trafilatura = "^2.0.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ lxml>=6.1.0,<7.0
 python-dotenv>=1.2.2,<2.0
 google-api-python-client>=2.196.0,<3.0
 platformdirs>=4.9.6,<5.0
+trafilatura>=2.0.0,<3.0

--- a/src/websearch/__init__.py
+++ b/src/websearch/__init__.py
@@ -1,4 +1,4 @@
 """WebSearch MCP Server - Advanced web search and content extraction."""
 
-__version__ = "2.2.0"
+__version__ = "2.3.0"
 __author__ = "Vishal Gupta"

--- a/src/websearch/core/content.py
+++ b/src/websearch/core/content.py
@@ -47,7 +47,7 @@ def fetch_single_page_content(url: str) -> str:
 
     try:
         response = make_request(url, CONTENT_TIMEOUT)
-        text = extract_text_content(response.text)
+        text = extract_text_content(response.text, url=url)
         result = _success_result(url, text)
         content_cache.set(cache_key, result)
         logger.info(f"Successfully fetched {len(text)} characters from {url}")
@@ -88,7 +88,7 @@ async def fetch_single_page_content_async(url: str) -> dict:
 
     try:
         response_text = await make_request_async(url, CONTENT_TIMEOUT)
-        text = extract_text_content(response_text)
+        text = extract_text_content(response_text, url=url)
         result = _success_result(url, text)
         content_cache.set(cache_key, result)
         logger.info(f"Successfully fetched {len(text)} characters from {url}")

--- a/src/websearch/utils/content.py
+++ b/src/websearch/utils/content.py
@@ -1,24 +1,86 @@
-"""Content processing utilities."""
+"""Content processing utilities.
 
+The primary extractor is Trafilatura, which strips boilerplate (nav, cookie
+banners, sidebars, footers) far more reliably than naive ``BeautifulSoup
+.get_text()``. On benchmark corpora it cuts boilerplate hits ~93% and output
+size ~20% with comparable latency. When Trafilatura returns nothing (empty
+DOM, anti-bot stub, very short pages) we fall back to BS4 so we never make
+the result *worse* than the previous behavior.
+"""
+
+import logging
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from bs4 import BeautifulSoup
 
+logger = logging.getLogger(__name__)
 
-def extract_text_content(html: str) -> str:
-    """Extract and clean text content from HTML"""
+try:
+    import trafilatura  # type: ignore[import-untyped]
+
+    _TRAFILATURA_AVAILABLE = True
+
+    # Trafilatura and its dependencies emit WARNING/ERROR for routine
+    # inputs (empty body, anti-bot stub, garbage HTML). The fallback path
+    # already handles these cases — the messages don't reflect real errors,
+    # they just pollute the MCP server's log file.
+    for _noisy in (
+        "trafilatura",
+        "trafilatura.core",
+        "trafilatura.utils",
+        "trafilatura.readability_lxml",
+        "htmldate",
+        "htmldate.core",
+    ):
+        logging.getLogger(_noisy).setLevel(logging.CRITICAL)
+except ImportError:
+    trafilatura = None  # type: ignore[assignment]
+    _TRAFILATURA_AVAILABLE = False
+    logger.warning(
+        "trafilatura not installed; falling back to raw BeautifulSoup "
+        "extraction. Install with: pip install trafilatura"
+    )
+
+
+def _bs4_fallback(html: str) -> str:
+    """Naive get_text-based extraction kept as last resort."""
     soup = BeautifulSoup(html, "html.parser")
-
-    # Remove script and style elements
     for script in soup(["script", "style"]):
         script.decompose()
-
-    # Get text content and clean whitespace
     text = soup.get_text()
     lines = (line.strip() for line in text.splitlines())
     chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
     return " ".join(chunk for chunk in chunks if chunk)
+
+
+def extract_text_content(html: str, url: Optional[str] = None) -> str:
+    """Extract clean article text from HTML.
+
+    Tries Trafilatura first (semantic boilerplate removal), falls back to
+    BeautifulSoup ``get_text`` if Trafilatura yields nothing. ``url`` is an
+    optional hint Trafilatura uses for some site-specific heuristics.
+    """
+    if _TRAFILATURA_AVAILABLE:
+        try:
+            # include_tables=True keeps reference/docs tables which are real
+            # content. include_comments=False drops user comment threads —
+            # they're rarely the value of a fetch_page_content call.
+            # favor_precision=False keeps recall up; the fallback covers
+            # the few cases where Trafilatura over-strips.
+            extracted = trafilatura.extract(
+                html,
+                url=url,
+                include_comments=False,
+                include_tables=True,
+                favor_precision=False,
+            )
+            if extracted and extracted.strip():
+                return extracted
+        except Exception as exc:  # noqa: BLE001 — defensive; never raise from extractor
+            logger.warning("trafilatura.extract raised, falling back to BS4: %s", exc)
+
+    return _bs4_fallback(html)
 
 
 def create_error_result(

--- a/tests/test_content_extraction.py
+++ b/tests/test_content_extraction.py
@@ -1,0 +1,123 @@
+"""Tests for utils.content.extract_text_content (Trafilatura + BS4 fallback)."""
+
+import logging
+
+import pytest
+
+from websearch.utils import content as content_mod
+from websearch.utils.content import extract_text_content
+
+ARTICLE_HTML = """
+<html><head><title>T</title></head>
+<body>
+  <nav>Site Nav | About | Contact</nav>
+  <header>Cookie banner: please accept our cookies</header>
+  <main>
+    <article>
+      <h1>The Article Title</h1>
+      <p>This is the first paragraph of real article content. It is long enough
+         that Trafilatura will treat it as the main body.</p>
+      <p>Second paragraph continues the discussion with more substantive prose
+         that any reasonable extractor should preserve in the output.</p>
+    </article>
+  </main>
+  <aside>Sidebar: subscribe to newsletter, follow us on social media</aside>
+  <footer>All rights reserved. Privacy Policy. Terms of Service.</footer>
+</body></html>
+"""
+
+EMPTY_HTML = "<html><body></body></html>"
+SHORT_HTML = "<html><body><p>too short</p></body></html>"
+
+
+def test_extract_real_article_strips_chrome():
+    out = extract_text_content(ARTICLE_HTML, url="https://example.com/article")
+    assert "first paragraph of real article content" in out
+    assert "Second paragraph continues" in out
+    # Boilerplate must be gone
+    assert "Cookie banner" not in out
+    assert "newsletter" not in out
+    assert "All rights reserved" not in out
+
+
+def test_extract_falls_back_when_trafilatura_returns_empty(monkeypatch):
+    """When Trafilatura yields '', the BS4 fallback runs."""
+    if not content_mod._TRAFILATURA_AVAILABLE:
+        pytest.skip("trafilatura not installed in this env")
+
+    monkeypatch.setattr(
+        content_mod.trafilatura, "extract", lambda *a, **kw: None
+    )
+    out = extract_text_content("<html><body><p>fallback content</p></body></html>")
+    assert "fallback content" in out
+
+
+def test_extract_falls_back_when_trafilatura_raises(monkeypatch):
+    """Defensive: an exception in Trafilatura must not propagate."""
+    if not content_mod._TRAFILATURA_AVAILABLE:
+        pytest.skip("trafilatura not installed in this env")
+
+    def _boom(*_a, **_kw):
+        raise RuntimeError("trafilatura is sad")
+
+    monkeypatch.setattr(content_mod.trafilatura, "extract", _boom)
+    out = extract_text_content("<html><body><p>still works</p></body></html>")
+    assert "still works" in out
+
+
+def test_extract_handles_completely_empty_html():
+    """Both extractors should return '' or near-empty without raising."""
+    out = extract_text_content(EMPTY_HTML)
+    assert out == "" or len(out.strip()) == 0
+
+
+def test_extract_short_page_uses_fallback_or_returns_text():
+    """Trafilatura might reject very short pages; fallback ensures we return
+    *something* useful so the LLM sees it instead of empty content."""
+    out = extract_text_content(SHORT_HTML)
+    assert "too short" in out
+
+
+def test_extract_passes_url_hint_to_trafilatura(monkeypatch):
+    """The URL hint must be forwarded — Trafilatura uses it for heuristics."""
+    if not content_mod._TRAFILATURA_AVAILABLE:
+        pytest.skip("trafilatura not installed in this env")
+
+    captured = {}
+
+    def _spy(html, **kwargs):
+        captured.update(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(content_mod.trafilatura, "extract", _spy)
+    extract_text_content("<html></html>", url="https://example.com/x")
+    assert captured.get("url") == "https://example.com/x"
+
+
+def test_extract_does_not_raise_on_invalid_html():
+    """Garbage in must not raise."""
+    out = extract_text_content("<<<not <html> at all>>>")
+    assert isinstance(out, str)
+
+
+def test_trafilatura_loggers_silenced(caplog):
+    """Routine empty/garbage extractions must NOT emit WARNING/ERROR logs.
+
+    Trafilatura and htmldate are noisy on malformed/empty inputs; we silence
+    them at import time so the MCP server's log file stays clean.
+    """
+    if not content_mod._TRAFILATURA_AVAILABLE:
+        pytest.skip("trafilatura not installed in this env")
+
+    with caplog.at_level(logging.WARNING):
+        # Each of these would emit warnings/errors on the trafilatura/htmldate
+        # loggers if we hadn't silenced them.
+        extract_text_content("")
+        extract_text_content("<html></html>")
+        extract_text_content("<<not html>>")
+
+    noisy = [
+        rec for rec in caplog.records
+        if rec.name.startswith(("trafilatura", "htmldate"))
+    ]
+    assert noisy == [], f"Expected no trafilatura/htmldate logs, got: {noisy}"


### PR DESCRIPTION
## Summary

Content extraction was the single biggest LLM-output-quality lever in this codebase: the previous `BeautifulSoup.get_text()` pipeline returned navigation, cookie banners, sidebars, and footers as part of "content." This PR swaps in **Trafilatura** as the primary extractor, with BS4 kept as a safety net for the small minority of pages where Trafilatura returns nothing (anti-bot stubs, very short pages).

Version: 2.2.0 → 2.3.0.

## Why this change

A market survey of comparable MCP search servers and commercial APIs (Tavily, Exa, Firecrawl) showed content extraction quality as the biggest gap between this MCP and the bar set by the rest of the field. The full analysis lives in `~/MyNotes/Personal/websearch-improvement-roadmap.md`.

## Benchmarks

A reproducible benchmark harness lives at `benchmarks/extractor_bench.py`. It fetches 8 representative URLs (Wikipedia, MDN, GitHub, BBC News, blogs, docs, Reddit) once, caches the HTML to `benchmarks/fixtures/`, and measures three extractors side-by-side.

| extractor | total_chars | total_ms | boilerplate_hits |
|---|---:|---:|---:|
| `bs4_old` (pre-PR) | 288,657 | 251 | **27** |
| **`current`** (Trafilatura + BS4 fallback) | **226,730** | **467** | **2** |

### Headline numbers
- **Boilerplate hits: -93%** (27 → 2 across the corpus)
- **Output size: -21%** (cleaner LLM context)
- **Latency: +86% aggregate, ~50ms/page average** — still I/O-bound in production where network dominates.

### Where the win is biggest
| fixture | size reduction | what was stripped |
|---|---:|---|
| BBC news | -77% | nav, related stories, footer, cookie banner |
| MDN | -71% | sidebar TOC, "see also", browser-compat noise |
| python docs | -52% | navigation tree, version selector, footer |
| GitHub README | -34% | repo nav, side panel, footer |

### Edge cases handled
- **Reddit anti-bot stub:** Trafilatura returns nothing; BS4 fallback recovers the 37 chars the old code returned. No regression.
- **Very short pages:** fall through to BS4.

## Behavior changes worth knowing

- Trafilatura returns paragraph-newline-separated text where the old extractor flattened to single-spaced. `MAX_CONTENT_LENGTH` still applies as a raw character budget; downstream consumers (ranking, dedup) tokenize on whitespace and are unaffected.
- In-memory content cache flushes on restart, so no migration of stale BS4-format cache entries is required.
- Trafilatura/htmldate sub-loggers silenced to `CRITICAL` at import time — they emit `WARNING`/`ERROR` for routine empty/garbage inputs that the fallback already handles, and we don't want them in the MCP server's log file.

## Independent code review

A separate review pass surfaced one major finding plus several minor items:

- **Major — Trafilatura log pollution:** the lib emits `WARNING`/`ERROR` for routine inputs (empty body, anti-bot stub, garbage HTML), which would land in the production log file. **Fixed:** silenced the relevant sub-loggers at import time and added a test asserting no `trafilatura`/`htmldate` log records leak through on routine inputs.
- **Minor:** documented the Trafilatura argument tradeoffs (`include_tables=True`, `include_comments=False`, `favor_precision=False`) inline.
- **Minor:** removed unused import in tests.

The note about whitespace-shape change (paragraph newlines vs single-spaced) and the in-memory-cache flush-on-restart were both verified non-issues for downstream code.

## Test plan

- [x] `pytest tests/ -m "not integration"` — 129 unit tests pass (was 121)
- [x] `pytest tests/ -m "integration"` — 13 live-network tests pass
- [x] `pylint src/websearch/` — 10.00/10
- [x] **8 new unit tests** for the extractor: article-strips-chrome, fallback-on-None, fallback-on-exception, URL-hint forwarding, empty/short/garbage HTML, log-silencing
- [x] Live e2e: Wikipedia fetch returns clean prose with zero `cookie`/`subscribe`/`privacy policy` markers in output. BBC news -77% size end-to-end through `fetch_page_content`.
- [x] Benchmark harness reproducible: `python benchmarks/extractor_bench.py` (uses cached fixtures) or `--refetch` for fresh.

## What's next

This is the first of three highest-leverage improvements identified in the post-merge analysis. Next up:
- URL dedup hardening (strip tracking params, normalize www/scheme/trailing-slash) — S effort
- Query-aware quality scoring (keyword overlap + freshness) — M effort

Both can be separate PRs — they're independent of this change.