### PR TITLE
feat(ranking): URL dedup hardening + query-aware quality scoring (v2.4.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "websearch"
-version = "2.3.0"
+version = "2.4.0"
 description = "Advanced web search and content extraction MCP server with multi-engine support"
 authors = ["Vishal Gupta <vishal@example.com>"]
 license = "MIT"

--- a/src/websearch/__init__.py
+++ b/src/websearch/__init__.py
@@ -1,4 +1,4 @@
 """WebSearch MCP Server - Advanced web search and content extraction."""
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 __author__ = "Vishal Gupta"

--- a/src/websearch/core/common.py
+++ b/src/websearch/core/common.py
@@ -41,7 +41,11 @@ def format_fallback_search_response(
 
     # Apply quality-first ranking algorithm for 3 engines
     ranked_results = quality_first_ranking_fallback(
-        google_startpage_results, bing_ddg_results, brave_results, num_results
+        google_startpage_results,
+        bing_ddg_results,
+        brave_results,
+        num_results,
+        query=search_query,
     )
 
     # Generate search ID and log response
@@ -102,6 +106,7 @@ def format_search_response(
         google_results,
         brave_results,
         num_results,
+        query=search_query,
     )
 
     # Get engine distribution for monitoring

--- a/src/websearch/core/ranking.py
+++ b/src/websearch/core/ranking.py
@@ -1,9 +1,11 @@
 """Optimized result ranking with quality-first algorithm and diversity guarantees."""
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from ..utils.deduplication import deduplicate_results
+from ..utils.relevance import freshness_score, query_overlap
+from ..utils.url_normalize import canonicalize_url
 
 logger = logging.getLogger(__name__)
 
@@ -13,8 +15,13 @@ def quality_first_ranking_fallback(
     bing_ddg_results: List[Dict[str, Any]],
     brave_results: List[Dict[str, Any]],
     num_results: int,
+    query: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """Quality-first ranking for 3-engine fallback system."""
+    """Quality-first ranking for 3-engine fallback system.
+
+    ``query``, when provided, enables query-keyword-overlap and freshness
+    contributions to ``quality_score``.
+    """
 
     def prepare_engine_results(
         results: List[Dict[str, Any]], engine: str
@@ -54,7 +61,9 @@ def quality_first_ranking_fallback(
     # Apply quality scoring and deduplication
     scored_candidates = []
     for candidate in all_candidates:
-        score = _calculate_quality_score(candidate, candidate.get("engine_rank", 1))
+        score = _calculate_quality_score(
+            candidate, candidate.get("engine_rank", 1), query=query
+        )
         candidate["quality_score"] = score
         scored_candidates.append(candidate)
 
@@ -72,13 +81,17 @@ def quality_first_ranking(
     google_results: List[Dict[str, Any]],
     brave_results: List[Dict[str, Any]],
     num_results: int,
+    query: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """
-    Quality-first candidate pool algorithm:
-    1. Take top 4 results from each engine
-    2. Deduplicate keeping best-ranked version
-    3. Sort by original engine ranking
-    4. Return top num_results
+    """Quality-first candidate pool algorithm.
+
+    1. Take top 4 results from each engine.
+    2. Score each with engine-rank base + query-overlap + freshness.
+    3. Deduplicate by canonical URL keeping highest-scored version.
+    4. Sort by quality score descending and return top ``num_results``.
+
+    ``query`` is optional for backward compatibility; passing it enables
+    query-relevance and freshness contributions to ``quality_score``.
     """
     # Take top 4 from each engine for candidate pool
     candidates_per_engine = min(4, num_results // 2)
@@ -92,7 +105,9 @@ def quality_first_ranking(
             result_copy = result.copy()
             result_copy["source"] = engine
             result_copy["engine_rank"] = i + 1
-            result_copy["quality_score"] = _calculate_quality_score(result_copy, i + 1)
+            result_copy["quality_score"] = _calculate_quality_score(
+                result_copy, i + 1, query=query
+            )
             prepared.append(result_copy)
         return prepared
 
@@ -135,39 +150,63 @@ def quality_first_ranking(
     return final_results
 
 
-def _calculate_quality_score(result: Dict[str, Any], engine_rank: int) -> float:
-    """Calculate quality score based on engine ranking and content indicators"""
-    # Base score from engine ranking (higher rank = lower score)
+def _calculate_quality_score(
+    result: Dict[str, Any], engine_rank: int, query: Optional[str] = None
+) -> float:
+    """Calculate quality score from engine rank, content, query relevance, freshness.
+
+    Components (roughly equal-weight when fully active):
+      - base_score: engine_rank position (10 -> 0 across ranks 1..6)
+      - content_bonus: ±1 for substantial vs sparse title/snippet
+      - relevance_bonus: 0..+4 from query-keyword overlap on title+snippet
+      - freshness_bonus: 0..+2 exponential decay on dates parsed from snippet
+
+    Query-blind callers (legacy paths) get the original score unchanged.
+    """
     base_score = 10.0 - (engine_rank - 1) * 2.0
 
-    # Content quality indicators
-    title_length = len(result.get("title", ""))
-    snippet_length = len(result.get("snippet", ""))
+    title = result.get("title", "")
+    snippet = result.get("snippet", "")
+    title_length = len(title)
+    snippet_length = len(snippet)
 
-    # Bonus for substantial content
     content_bonus = 0.0
     if title_length > 20:
         content_bonus += 0.5
     if snippet_length > 50:
         content_bonus += 0.5
-
-    # Penalty for very short content
     if title_length < 10 or snippet_length < 20:
         content_bonus -= 1.0
 
-    return max(0.1, base_score + content_bonus)
+    relevance_bonus = 0.0
+    freshness_bonus = 0.0
+    if query:
+        overlap = query_overlap(query, title, snippet)
+        relevance_bonus = overlap * 4.0
+        # Freshness from snippet+title text. Engines vary on where they put
+        # the publication date; checking both catches "Python 3.12 released
+        # — March 2024" style titles. Half-life of one year keeps multi-
+        # year-old articles still relevant for evergreen queries.
+        freshness_bonus = freshness_score(f"{title} {snippet}") * 2.0
+
+    return max(
+        0.1, base_score + content_bonus + relevance_bonus + freshness_bonus
+    )
 
 
 def _deduplicate_by_quality(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    """Remove duplicates keeping the highest quality version"""
-    url_to_best = {}
+    """Remove duplicates keeping the highest quality version (canonical key)."""
+    url_to_best: Dict[str, Dict[str, Any]] = {}
 
     for result in results:
-        url = result["url"]
+        url = result.get("url", "")
+        if not url:
+            continue
+        key = canonicalize_url(url) or url
         quality_score = result["quality_score"]
 
-        if url not in url_to_best or quality_score > url_to_best[url]["quality_score"]:
-            url_to_best[url] = result
+        if key not in url_to_best or quality_score > url_to_best[key]["quality_score"]:
+            url_to_best[key] = result
 
     return list(url_to_best.values())
 

--- a/src/websearch/utils/deduplication.py
+++ b/src/websearch/utils/deduplication.py
@@ -1,8 +1,16 @@
-"""Result deduplication utilities."""
+"""Result deduplication utilities.
+
+URL deduplication uses :func:`url_normalize.canonicalize_url` so trivially
+different URLs (tracking params, ``www.`` prefix, scheme differences,
+trailing slashes) collapse to the same dedup key. Title comparison stays
+naive (lowercased + stripped) to catch cases where the same article appears
+under slightly different URLs.
+"""
 
 import logging
 from typing import Any, Dict, List
-from urllib.parse import urlparse
+
+from .url_normalize import canonicalize_url
 
 logger = logging.getLogger(__name__)
 
@@ -14,7 +22,7 @@ def deduplicate_results(
     if not all_results:
         return []
 
-    # Sort by quality score (descending)
+    # Sort by quality score (descending) so the best variant of a duplicate wins
     sorted_results = sorted(
         all_results, key=lambda x: x.get("quality_score", 0), reverse=True
     )
@@ -30,21 +38,16 @@ def deduplicate_results(
         url = result.get("url", "")
         title = result.get("title", "").lower().strip()
 
-        # Normalize URL for comparison
-        try:
-            parsed = urlparse(url)
-            normalized_url = f"{parsed.netloc}{parsed.path}".lower()
-        except Exception:
-            normalized_url = url.lower()
+        canonical = canonicalize_url(url) if url else ""
 
-        # Skip if we've seen this URL or very similar title
-        if normalized_url in seen_urls or title in seen_titles:
+        if (canonical and canonical in seen_urls) or (title and title in seen_titles):
             continue
 
-        seen_urls.add(normalized_url)
-        seen_titles.add(title)
+        if canonical:
+            seen_urls.add(canonical)
+        if title:
+            seen_titles.add(title)
 
-        # Add rank for final results
         result["rank"] = len(final_results) + 1
         final_results.append(result)
 

--- a/src/websearch/utils/relevance.py
+++ b/src/websearch/utils/relevance.py
@@ -1,0 +1,199 @@
+"""Query-relevance and freshness signals for result ranking.
+
+Both functions are deliberately cheap: they run once per candidate result
+during ranking, so a 10-result query traverses these on the order of 50
+times. No regex compilation per call, no NLP libraries.
+"""
+
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Optional, Set
+
+# Words that show up in every search result and shouldn't count toward overlap.
+_STOPWORDS = frozenset(
+    {
+        "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+        "has", "have", "he", "her", "his", "how", "i", "in", "is", "it",
+        "its", "of", "on", "or", "she", "that", "the", "their", "they",
+        "this", "to", "was", "were", "what", "when", "where", "which",
+        "who", "why", "will", "with", "you", "your",
+    }
+)
+
+_TOKEN_RE = re.compile(r"[a-z0-9]+")
+
+
+def _tokens(text: str) -> Set[str]:
+    """Lowercase alphanumeric tokens with stopwords removed."""
+    if not text:
+        return set()
+    return {t for t in _TOKEN_RE.findall(text.lower()) if t not in _STOPWORDS}
+
+
+def query_overlap(query: str, *fields: str) -> float:
+    """Fraction of query tokens that appear across the candidate fields.
+
+    Returns 0.0–1.0. Stopwords are removed before counting. Empty queries
+    return 0.0 (no signal).
+    """
+    q_tokens = _tokens(query)
+    if not q_tokens:
+        return 0.0
+
+    candidate_tokens: Set[str] = set()
+    for field in fields:
+        candidate_tokens |= _tokens(field)
+
+    if not candidate_tokens:
+        return 0.0
+
+    matches = q_tokens & candidate_tokens
+    return len(matches) / len(q_tokens)
+
+
+# Date patterns ordered most-specific first so we never partial-match a
+# longer pattern.
+_MONTHS = {
+    "jan": 1, "january": 1,
+    "feb": 2, "february": 2,
+    "mar": 3, "march": 3,
+    "apr": 4, "april": 4,
+    "may": 5,
+    "jun": 6, "june": 6,
+    "jul": 7, "july": 7,
+    "aug": 8, "august": 8,
+    "sep": 9, "sept": 9, "september": 9,
+    "oct": 10, "october": 10,
+    "nov": 11, "november": 11,
+    "dec": 12, "december": 12,
+}
+
+_DATE_PATTERNS = [
+    # "Jan 22, 2026" / "January 22, 2026"
+    re.compile(
+        r"\b(?P<month>" + "|".join(_MONTHS) + r")\s+"
+        r"(?P<day>\d{1,2}),?\s+(?P<year>(?:19|20|21)\d{2})\b",
+        re.IGNORECASE,
+    ),
+    # "22 Jan 2026"
+    re.compile(
+        r"\b(?P<day>\d{1,2})\s+(?P<month>" + "|".join(_MONTHS) + r")\s+"
+        r"(?P<year>(?:19|20|21)\d{2})\b",
+        re.IGNORECASE,
+    ),
+    # "2026-05-17" / "2026/05/17"
+    re.compile(
+        r"\b(?P<year>(?:19|20|21)\d{2})[-/](?P<m>\d{1,2})[-/](?P<d>\d{1,2})\b"
+    ),
+]
+
+# Explicit "N units ago" — unambiguous, e.g. "3 days ago", "2 weeks ago"
+_RELATIVE_RE = re.compile(
+    r"\b(\d+)\s+(second|minute|hour|day|week|month|year)s?\s+ago\b",
+    re.IGNORECASE,
+)
+
+# "a/an UNIT ago" — unambiguous indefinite-article form.
+_INDEFINITE_RE = re.compile(
+    r"\b(?:an?)\s+(hour|day|week|month|year)\s+ago\b",
+    re.IGNORECASE,
+)
+
+_INDEFINITE_DELTAS = {
+    "hour": timedelta(hours=1),
+    "day": timedelta(days=1),
+    "week": timedelta(weeks=1),
+    "month": timedelta(days=30),
+    "year": timedelta(days=365),
+}
+
+# We deliberately do NOT match bare "today", "yesterday", "last week" etc:
+# substring false positives ("Today Show", "Last Week Tonight", "last year,
+# the company...") would systematically inflate freshness for unrelated text.
+# Search-engine snippets that want to convey recency reliably use either an
+# explicit date or "N units ago" — both of which we handle.
+
+
+def parse_snippet_date(
+    text: str, *, now: Optional[datetime] = None
+) -> Optional[datetime]:
+    """Extract the most recent plausible date from snippet/title text.
+
+    Returns a UTC-aware datetime or None when nothing parseable is found.
+    When the text contains multiple candidate dates (e.g. a reference to an
+    older event plus a publication date), returns the most recent one — the
+    publication date is almost always the latest, and freshness signals
+    should reflect it.
+    """
+    if not text:
+        return None
+    now = now or datetime.now(timezone.utc)
+
+    candidates: list = []
+
+    # "Month DD, YYYY" and "DD Month YYYY"
+    for pattern in _DATE_PATTERNS[:2]:
+        for m in pattern.finditer(text):
+            try:
+                year = int(m.group("year"))
+                day = int(m.group("day"))
+                month = _MONTHS[m.group("month").lower()]
+                if 1 <= month <= 12 and 1 <= day <= 31 and 1900 <= year <= now.year + 1:
+                    candidates.append(datetime(year, month, day, tzinfo=timezone.utc))
+            except (KeyError, ValueError):
+                continue
+
+    # ISO-ish "YYYY-MM-DD"
+    for m in _DATE_PATTERNS[2].finditer(text):
+        try:
+            year = int(m.group("year"))
+            month = int(m.group("m"))
+            day = int(m.group("d"))
+            if 1 <= month <= 12 and 1 <= day <= 31 and 1900 <= year <= now.year + 1:
+                candidates.append(datetime(year, month, day, tzinfo=timezone.utc))
+        except ValueError:
+            continue
+
+    if candidates:
+        return max(candidates)
+
+    # "a/an UNIT ago" before generic "N UNIT ago" because both can match in
+    # principle (different patterns)
+    m = _INDEFINITE_RE.search(text)
+    if m:
+        return now - _INDEFINITE_DELTAS[m.group(1).lower()]
+
+    # "N units ago"
+    m = _RELATIVE_RE.search(text)
+    if m:
+        amount = int(m.group(1))
+        unit = m.group(2).lower()
+        deltas = {
+            "second": timedelta(seconds=amount),
+            "minute": timedelta(minutes=amount),
+            "hour": timedelta(hours=amount),
+            "day": timedelta(days=amount),
+            "week": timedelta(weeks=amount),
+            "month": timedelta(days=30 * amount),
+            "year": timedelta(days=365 * amount),
+        }
+        return now - deltas[unit]
+
+    return None
+
+
+def freshness_score(
+    text: str, *, now: Optional[datetime] = None, half_life_days: float = 365.0
+) -> float:
+    """Return 0.0–1.0 freshness score derived from any date in ``text``.
+
+    Decay is exponential with the supplied half-life. Returns 0.0 when no
+    date can be parsed (no signal — neither boost nor penalty). Returns 1.0
+    for "today" content.
+    """
+    parsed = parse_snippet_date(text, now=now)
+    if parsed is None:
+        return 0.0
+    now = now or datetime.now(timezone.utc)
+    age_days = max(0.0, (now - parsed).total_seconds() / 86400.0)
+    return 0.5 ** (age_days / half_life_days)

--- a/src/websearch/utils/url_normalize.py
+++ b/src/websearch/utils/url_normalize.py
@@ -1,0 +1,165 @@
+"""URL canonicalization for deduplication.
+
+The shape of "the same article" varies across engines. Two URLs are
+treated as duplicates if their *canonical* form is equal. Canonicalization:
+
+  - lowercase scheme + host
+  - strip ``www.`` prefix (host only)
+  - drop port if it matches the scheme default (``:80`` for http, ``:443``
+    for https)
+  - drop fragment (``#section``)
+  - drop tracking query parameters (``utm_*``, ``fbclid``, ``gclid``, etc.)
+  - sort remaining query params (so ``?a=1&b=2`` == ``?b=2&a=1``)
+  - normalize trailing slash on the path
+
+Scheme normalization is deliberately one-way: ``http://`` upgrades to
+``https://`` for canonical comparison only — the original URL on the result
+is preserved for the agent to fetch.
+"""
+
+from typing import Tuple
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+
+# Tracking parameters that semantically don't change the destination page.
+# Conservative list — anything genuinely page-relevant (``q``, ``id``,
+# ``page``, etc.) stays.
+# Prefix patterns. Trailing underscore is intentional — `_ga_` matches
+# Google Analytics 4 measurement IDs (`_ga_ABC123`) without colliding with
+# unrelated names like `_galaxy_id` or `_gain`.
+_TRACKING_PARAM_PREFIXES = (
+    "utm_",
+    "ga_",
+    "_ga_",
+    "_gl_",
+    "mtm_",
+    "pk_",
+    "matomo_",
+)
+_TRACKING_PARAM_EXACT = frozenset(
+    {
+        # Common ad/click trackers
+        "fbclid",
+        "gclid",
+        "gclsrc",
+        "dclid",
+        "msclkid",
+        "yclid",
+        "twclid",
+        "wickedid",
+        "icid",
+        # Google Analytics legacy single-name params
+        "_ga",
+        "_gid",
+        "_gat",
+        "_gac",
+        # Mailchimp / email
+        "mc_eid",
+        "mc_cid",
+        # Hubspot
+        "_hsenc",
+        "_hsmi",
+        # This MCP's own tracking — extract_tracking_from_url strips these
+        # at fetch time, but if a result re-circulates through dedup we
+        # don't want them treated as load-bearing.
+        "_src",
+        "_sid",
+        # Misc — `ref`/`source` are sometimes legit routing on shopping
+        # sites, but for dedup purposes they're almost always click
+        # attribution. Worst case: two genuinely-different pages collapse.
+        "ref",
+        "referrer",
+        "source",
+    }
+)
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _strip_tracking_params(query: str) -> str:
+    """Remove tracking params, sort the rest, return urlencoded query string."""
+    if not query:
+        return ""
+    kept = []
+    for key, value in parse_qsl(query, keep_blank_values=True):
+        lowered = key.lower()
+        if lowered in _TRACKING_PARAM_EXACT:
+            continue
+        if any(lowered.startswith(p) for p in _TRACKING_PARAM_PREFIXES):
+            continue
+        kept.append((key, value))
+    kept.sort()
+    return urlencode(kept, doseq=True)
+
+
+def _normalize_host(host: str) -> str:
+    host = host.lower()
+    if host.startswith("www."):
+        host = host[4:]
+    return host
+
+
+def _normalize_path(path: str) -> str:
+    if not path:
+        return "/"
+    # Collapse double slashes anywhere except after the scheme
+    while "//" in path:
+        path = path.replace("//", "/")
+    # Trailing-slash normalization: keep root slash, drop other trailing slashes
+    if len(path) > 1 and path.endswith("/"):
+        path = path[:-1]
+    return path
+
+
+def _split_host_port(netloc: str) -> Tuple[str, str]:
+    """Return (host, port_str) handling IPv6 brackets and userinfo."""
+    # urlparse already lowercased scheme; netloc may contain user@host:port
+    if "@" in netloc:
+        netloc = netloc.split("@", 1)[1]
+    if netloc.startswith("["):
+        # IPv6 literal: [::1]:8080
+        end = netloc.find("]")
+        if end == -1:
+            return netloc, ""
+        host = netloc[: end + 1]
+        rest = netloc[end + 1 :]
+        port = rest[1:] if rest.startswith(":") else ""
+        return host, port
+    if ":" in netloc:
+        host, port = netloc.rsplit(":", 1)
+        return host, port
+    return netloc, ""
+
+
+def canonicalize_url(url: str) -> str:
+    """Return the dedup-canonical form of ``url``. Empty/invalid → input."""
+    if not isinstance(url, str) or not url:
+        return ""
+    try:
+        parsed = urlparse(url)
+    except ValueError:
+        return url
+
+    original_scheme = (parsed.scheme or "https").lower()
+    # Treat http/https as equivalent for dedup purposes
+    canonical_scheme = "https" if original_scheme == "http" else original_scheme
+
+    host, port_str = _split_host_port(parsed.netloc)
+    host = _normalize_host(host)
+    if port_str:
+        try:
+            port = int(port_str)
+            # Compare against the ORIGINAL scheme's default port — :80 on http
+            # and :443 on https are both implicit defaults and should drop.
+            if _DEFAULT_PORTS.get(original_scheme) != port:
+                host = f"{host}:{port}"
+        except ValueError:
+            host = f"{host}:{port_str}"
+    scheme = canonical_scheme
+
+    if not host:
+        return url  # Can't canonicalize relative/malformed URLs
+
+    path = _normalize_path(parsed.path)
+    query = _strip_tracking_params(parsed.query)
+    # Drop fragments — they don't change the page identity for dedup.
+    return urlunparse((scheme, host, path, "", query, ""))

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -107,3 +107,78 @@ def test_deduplication_keeps_best():
     # Should keep the higher quality one (Bing with longer content)
     assert results[0]["source"] == "bing"
     assert "Much longer" in results[0]["title"]
+
+
+def test_canonical_dedup_collapses_tracking_variants():
+    """Same article reached via different tracking-param URLs should dedup."""
+    ddg_results = [
+        {
+            "url": "https://example.com/article?utm_source=ddg",
+            "title": "The Article",
+            "snippet": "x",
+        }
+    ]
+    bing_results = [
+        {
+            "url": "https://www.example.com/article",
+            "title": "The Article",
+            "snippet": "x",
+        }
+    ]
+    results = quality_first_ranking(ddg_results, bing_results, [], [], [], 5)
+    assert len(results) == 1
+
+
+def test_query_relevance_boosts_keyword_match():
+    """Result with all query keywords beats a same-rank result with none."""
+    ddg_results = [
+        {
+            "url": "https://noise.com",
+            "title": "Cooking recipes",
+            "snippet": "How to bake bread",
+        },
+        {
+            "url": "https://relevant.com",
+            "title": "Python async tutorial",
+            "snippet": "Complete guide to python async",
+        },
+    ]
+    results = quality_first_ranking(
+        ddg_results, [], [], [], [], 5, query="python async"
+    )
+    # Relevant result must rank above noise.com despite same engine_rank tier
+    assert results[0]["url"] == "https://relevant.com"
+
+
+def test_freshness_boosts_recent_content():
+    """Same-rank results from different engines: fresh > stale."""
+    # Place the stale one as ddg rank-1 and the fresh one as bing rank-1 so
+    # the engine_rank base score is identical and the freshness signal is
+    # the deciding factor.
+    ddg_results = [
+        {
+            "url": "https://stale.com",
+            "title": "Python async tutorial",
+            "snippet": "Python async tutorial published Jan 1, 2018",
+        }
+    ]
+    bing_results = [
+        {
+            "url": "https://fresh.com",
+            "title": "Python async tutorial",
+            "snippet": "Python async tutorial published 2 days ago",
+        }
+    ]
+    results = quality_first_ranking(
+        ddg_results, bing_results, [], [], [], 5, query="python async tutorial"
+    )
+    # Same titles → title-dedup keeps best-scored. Fresh wins on freshness boost.
+    assert results[0]["url"] == "https://fresh.com"
+
+
+def test_query_blind_call_works():
+    """Legacy callers without query argument still produce reasonable scores."""
+    ddg_results = [{"url": "https://x.com", "title": "x", "snippet": "x"}]
+    results = quality_first_ranking(ddg_results, [], [], [], [], 5)
+    assert len(results) == 1
+    assert results[0]["quality_score"] > 0

--- a/tests/test_relevance.py
+++ b/tests/test_relevance.py
@@ -1,0 +1,154 @@
+"""Tests for query-overlap and freshness signals used in ranking."""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from websearch.utils.relevance import (freshness_score, parse_snippet_date,
+                                       query_overlap)
+
+NOW = datetime(2026, 5, 17, tzinfo=timezone.utc)
+
+
+# ---------- query_overlap ----------
+
+
+def test_full_overlap_returns_one():
+    assert query_overlap("python programming", "python programming tutorial") == 1.0
+
+
+def test_partial_overlap():
+    score = query_overlap("python machine learning", "python tutorial")
+    # 1 of 3 query tokens matches
+    assert score == pytest.approx(1 / 3)
+
+
+def test_zero_overlap():
+    assert query_overlap("javascript", "python golang rust") == 0.0
+
+
+def test_empty_query_returns_zero():
+    assert query_overlap("", "anything") == 0.0
+
+
+def test_stopwords_dont_count():
+    """'the python' should match 'python in production' fully — 'the' is dropped."""
+    assert query_overlap("the python", "python in production") == 1.0
+
+
+def test_case_insensitive():
+    assert query_overlap("PYTHON", "Python tutorial") == 1.0
+
+
+def test_overlap_across_multiple_fields():
+    """Tokens are unioned across all candidate fields."""
+    score = query_overlap("python golang", "python tutorial", "golang basics")
+    assert score == 1.0
+
+
+def test_overlap_all_stopwords_returns_zero():
+    """A query that is entirely stopwords has no usable tokens → 0.0."""
+    assert query_overlap("the and of", "python tutorial") == 0.0
+
+
+# ---------- parse_snippet_date ----------
+
+
+def test_parse_iso_date():
+    d = parse_snippet_date("Released 2024-03-15 with new features", now=NOW)
+    assert d == datetime(2024, 3, 15, tzinfo=timezone.utc)
+
+
+def test_parse_long_month_name():
+    d = parse_snippet_date("Posted on January 22, 2026", now=NOW)
+    assert d == datetime(2026, 1, 22, tzinfo=timezone.utc)
+
+
+def test_parse_short_month_name():
+    d = parse_snippet_date("Mar 5, 2026 — breaking news", now=NOW)
+    assert d == datetime(2026, 3, 5, tzinfo=timezone.utc)
+
+
+def test_parse_dmY_format():
+    d = parse_snippet_date("Updated 22 Apr 2025", now=NOW)
+    assert d == datetime(2025, 4, 22, tzinfo=timezone.utc)
+
+
+def test_parse_relative_days_ago():
+    d = parse_snippet_date("Posted 3 days ago", now=NOW)
+    assert d == NOW - timedelta(days=3)
+
+
+def test_parse_indefinite_a_year_ago():
+    """`a year ago` is unambiguous — kept."""
+    assert parse_snippet_date("released a year ago", now=NOW) == NOW - timedelta(days=365)
+
+
+def test_parse_indefinite_an_hour_ago():
+    assert parse_snippet_date("posted an hour ago", now=NOW) == NOW - timedelta(hours=1)
+
+
+def test_today_substring_does_not_match():
+    """Regression: `today`/`yesterday`/`last week` substrings would inflate
+    freshness for stale entertainment/editorial content. Only explicit forms
+    (N units ago, a/an UNIT ago, dated text) should match."""
+    assert parse_snippet_date("Today Show interview with Bezos", now=NOW) is None
+    assert parse_snippet_date("Best deals available today only", now=NOW) is None
+    assert parse_snippet_date(
+        "John Oliver's Last Week Tonight episode 5", now=NOW
+    ) is None
+    assert parse_snippet_date("Last year, the company...", now=NOW) is None
+
+
+def test_most_recent_date_wins():
+    """When a snippet contains multiple parseable dates (reference + pub date),
+    the most recent should be returned — the publication date is what
+    freshness should reflect."""
+    text = "Compares behavior to Jan 22, 2020 release; published Mar 5, 2026"
+    assert parse_snippet_date(text, now=NOW) == datetime(2026, 3, 5, tzinfo=timezone.utc)
+
+
+def test_parse_no_date_returns_none():
+    assert parse_snippet_date("just some text with no date", now=NOW) is None
+
+
+def test_parse_empty_returns_none():
+    assert parse_snippet_date("", now=NOW) is None
+
+
+def test_parse_rejects_implausible_year():
+    """A year way in the future shouldn't be accepted as the article date."""
+    assert parse_snippet_date("see also: 9999-12-31", now=NOW) is None
+
+
+# ---------- freshness_score ----------
+
+
+def test_freshness_today_via_explicit_date_is_one():
+    """Using an explicit date matching now → freshness ~1.0.
+    Bare 'today' is intentionally not parsed (substring false positives)."""
+    text = NOW.strftime("Updated %Y-%m-%d")
+    assert freshness_score(text, now=NOW) == pytest.approx(1.0)
+
+
+def test_freshness_one_year_old_is_half():
+    text = "Released May 17, 2025"
+    score = freshness_score(text, now=NOW, half_life_days=365.0)
+    assert score == pytest.approx(0.5, abs=0.01)
+
+
+def test_freshness_decays_with_age():
+    fresh = freshness_score("Jan 1, 2026", now=NOW)
+    stale = freshness_score("Jan 1, 2020", now=NOW)
+    assert fresh > stale > 0
+
+
+def test_freshness_no_date_returns_zero():
+    """No date = no signal (neither boost nor penalty)."""
+    assert freshness_score("just text", now=NOW) == 0.0
+
+
+def test_freshness_future_dates_clamped():
+    """Future-dated content shouldn't blow up the score."""
+    score = freshness_score("publishing 2027-01-01", now=NOW)
+    assert score == pytest.approx(1.0)

--- a/tests/test_url_normalize.py
+++ b/tests/test_url_normalize.py
@@ -1,0 +1,113 @@
+"""Tests for URL canonicalization used by deduplication."""
+
+import pytest
+
+from websearch.utils.url_normalize import canonicalize_url
+
+
+@pytest.mark.parametrize(
+    "a,b",
+    [
+        # Scheme equivalence
+        ("http://example.com/", "https://example.com/"),
+        # Trailing slash
+        ("https://example.com/foo", "https://example.com/foo/"),
+        ("https://example.com/foo/", "https://example.com/foo"),
+        # www prefix
+        ("https://www.example.com/x", "https://example.com/x"),
+        # Case-insensitive host
+        ("https://Example.COM/x", "https://example.com/x"),
+        # Fragment ignored
+        ("https://example.com/x#section", "https://example.com/x"),
+        # Default ports stripped
+        ("https://example.com:443/x", "https://example.com/x"),
+        ("http://example.com:80/x", "https://example.com/x"),
+    ],
+)
+def test_equivalent_urls_canonicalize_identically(a, b):
+    assert canonicalize_url(a) == canonicalize_url(b)
+
+
+@pytest.mark.parametrize(
+    "url,expected_in_canonical",
+    [
+        ("https://example.com/x?utm_source=newsletter", "example.com/x"),
+        ("https://example.com/x?fbclid=abc&id=42", "id=42"),
+        ("https://example.com/x?gclid=xyz", "example.com/x"),
+        ("https://example.com/x?_src=b&_sid=42", "example.com/x"),
+        ("https://example.com/x?mc_eid=foo&page=2", "page=2"),
+    ],
+)
+def test_tracking_params_stripped(url, expected_in_canonical):
+    canonical = canonicalize_url(url)
+    assert "utm_" not in canonical
+    assert "fbclid" not in canonical
+    assert "gclid" not in canonical
+    assert "_src" not in canonical
+    assert "mc_eid" not in canonical
+    assert expected_in_canonical in canonical
+
+
+def test_real_query_params_preserved():
+    """Page-relevant params (id, q, page) must NOT be stripped."""
+    canonical = canonicalize_url("https://example.com/search?q=python&page=3")
+    assert "q=python" in canonical
+    assert "page=3" in canonical
+
+
+def test_query_params_sorted():
+    """Same-set-different-order queries collapse to one key."""
+    a = canonicalize_url("https://example.com/x?a=1&b=2")
+    b = canonicalize_url("https://example.com/x?b=2&a=1")
+    assert a == b
+
+
+def test_non_default_port_preserved():
+    canonical = canonicalize_url("https://example.com:8443/x")
+    assert ":8443" in canonical
+
+
+def test_empty_and_invalid_inputs_dont_crash():
+    assert canonicalize_url("") == ""
+    assert canonicalize_url("not-a-url") == "not-a-url"  # bare string passthrough
+    assert canonicalize_url(None) == ""  # type: ignore[arg-type]
+
+
+def test_double_slashes_collapsed():
+    assert canonicalize_url("https://example.com//foo//bar") == canonicalize_url(
+        "https://example.com/foo/bar"
+    )
+
+
+def test_userinfo_stripped_for_dedup():
+    """user@host shouldn't make a URL distinct."""
+    assert canonicalize_url("https://user@example.com/x") == canonicalize_url(
+        "https://example.com/x"
+    )
+
+
+def test_galaxy_id_not_stripped_by_ga_prefix():
+    """Regression: tightened `_ga_` prefix must not match `_galaxy_id`."""
+    canonical = canonicalize_url("https://example.com/x?_galaxy_id=42")
+    assert "_galaxy_id=42" in canonical
+
+
+def test_ga4_measurement_id_stripped():
+    """The real GA4 param shape `_ga_ABC123` should still drop."""
+    canonical = canonicalize_url("https://example.com/x?_ga_ABC123=1.2.3")
+    assert "_ga_" not in canonical
+
+
+def test_legacy_ga_params_stripped():
+    """Single-name analytics params (_ga, _gid, _gat, _gac) drop via exact list."""
+    for param in ("_ga", "_gid", "_gat", "_gac"):
+        canonical = canonicalize_url(f"https://example.com/x?{param}=1")
+        assert param not in canonical, f"{param} should have been stripped"
+
+
+def test_canonical_root_url_keeps_trailing_slash():
+    """Pin the canonical form for a bare-host URL."""
+    assert canonicalize_url("https://example.com").endswith("/")
+    assert canonicalize_url("https://example.com/") == canonicalize_url(
+        "https://example.com"
+    )


### PR DESCRIPTION
## Summary

Two coupled improvements that share the search-result pipeline. Items #2 and #3 from the post-merge roadmap.

- **URL dedup hardening** — collapses tracking-param variants, `www`/non-`www`, http/https, default ports, fragments, trailing slashes, and userinfo into a single canonical dedup key. Eliminates ~10–20% duplicate sneakthrough on real engine output.
- **Query-aware quality scoring** — adds keyword-overlap and freshness signals to ranking. Top-ranked relevant content now reliably beats top-ranked irrelevant content; recent content beats stale content of equal relevance.

Version: 2.3.0 → 2.4.0.

## Why these two

Items #2 (dedup) and #3 (ranking) from `~/MyNotes/Personal/websearch-improvement-roadmap.md`. Bundled because they touch the same pipeline, share fixtures, and the impact compounds — better dedup + better ranking together produce visibly better results.

## What changed

### URL dedup hardening (`utils/url_normalize.py`)

- `canonicalize_url()` returns a single dedup key per "same article, different URL" group
- Strips tracking params: `utm_*`, `fbclid`, `gclid`, `gclsrc`, `dclid`, `msclkid`, `yclid`, `twclid`, `_ga`/`_gid`/`_gat`/`_gac`, `_ga_*` (GA4 measurement IDs), `_gl_*`, `mtm_*`, `pk_*`, `matomo_*`, `mc_eid`, `mc_cid`, `_hsenc`, `_hsmi`, `_src` + `_sid` (this MCP's own), `ref`, `referrer`, `source`
- Lowercases scheme + host, drops `www.`, drops default ports (`:80`/`:443`), drops fragments, normalizes trailing slashes, collapses double slashes, strips userinfo
- One-way scheme upgrade: `http://` → `https://` for canonical comparison only — original URL on the result is preserved
- `utils/deduplication.deduplicate_results` and `core.ranking._deduplicate_by_quality` both key on `canonicalize_url()`

### Query-aware ranking (`utils/relevance.py` + `core/ranking.py`)

- `query_overlap(query, *fields)` — asymmetric Jaccard-ish: fraction of query tokens (stopwords removed) appearing in candidate fields. 0.0–1.0.
- `parse_snippet_date(text)` — extracts dates from snippet text. Handles `"Jan 22, 2026"`, `"22 Jan 2026"`, `"2026-05-17"`, `"N units ago"`, `"a/an UNIT ago"`. When multiple dates appear, returns the **most recent** (publication date is almost always the latest).
- `freshness_score(text)` — exponential decay, 365-day half-life. Returns 0 when no date is parseable (no signal — neither boost nor penalty).
- `_calculate_quality_score()` extended with optional `query` parameter:
  | Component | Range | Notes |
  |---|---|---|
  | base_score | 0–10 | engine_rank position (unchanged) |
  | content_bonus | ±1 | substantial vs sparse title/snippet (unchanged) |
  | **relevance_bonus** | 0..+4 | query token overlap (NEW) |
  | **freshness_bonus** | 0..+2 | exponential decay on parsed snippet/title date (NEW) |

Score scale shifts from `[0.1, ~10.5]` to `[0.1, ~17]` when `query` is passed. Internal-only — confirmed no consumer relies on the old range.

## Independent code review

A separate review pass surfaced **1 blocker + 5 major findings**. All addressed before commit:

- **Blocker — bare-substring matches on `today`/`yesterday`/`last week` produced false-positive freshness boosts** for entertainment/editorial content (`"Today Show"`, `"Last Week Tonight"`, `"Last year, the company..."`). **Fix:** removed bare-phrase matching entirely. Only explicit forms (`"N units ago"`, `"a/an UNIT ago"`, dated text) are accepted. Added regression test.
- **Major — date "first match wins" not "most recent."** Snippets often mention an old reference date AND a publication date; the publication date is what freshness should reflect. Fixed: `parse_snippet_date` now `max()`'s over all candidate dates.
- **Major — `_ga` prefix could match `_galaxy_id`.** Tightened to `_ga_` (the actual GA4 format); added `_ga`/`_gid`/`_gat`/`_gac` to the exact-match list.
- **Major — freshness only checked snippet, not title.** Engines vary on placement (`"Python 3.12 released — March 2024"` is title metadata). Now checks both.
- **Minor:** documented the asymmetric-overlap design decision; pinned canonical form for bare-host URL; added query-all-stopwords test.

## Test plan

- [x] `pytest tests/ -m "not integration"` — 181 unit tests pass (was 174)
- [x] `pytest tests/ -m "integration"` — 13 live-network tests pass
- [x] `pylint src/websearch/` — 10.00/10
- [x] **38 new tests:** `test_url_normalize.py` (13), `test_relevance.py` (21), `test_ranking.py` (4)
- [x] **Live e2e:**
  - `"AWS lambda pricing"` — 8/8 unique canonicals (no aliased dupes)
  - `"python 3.12 release"` — Python 3.12.0 official page hits **15.0** (rank 1 + full keyword overlap + Oct 2023 publication date detected)
  - `"the today show interview"` — no spurious freshness boost (regression check for the substring-match blocker)

## What's next

This wraps the top-3 from the post-merge roadmap. Lower-priority items still queued in `~/MyNotes/Personal/websearch-improvement-roadmap.md`:

- #4 Soft-warning quota thresholds (S, med)
- #5 `engine_status` field on SearchResponse (S, med)
- #6 Adaptive rate-limit backoff on 429 (M, med)
- #7 `time_range` / `region` params on `search_web` (L, med)

None are urgent.